### PR TITLE
Use collections.abc for the Iterable class

### DIFF
--- a/values/__init__.py
+++ b/values/__init__.py
@@ -1,11 +1,11 @@
 __all__ = ['get']
 
 
-import collections
+import collections.abc
 
 
 def _iterable(obj):
-    return isinstance(obj, collections.Iterable)
+    return isinstance(obj, collections.abc.Iterable)
 
 
 def _string(value):


### PR DESCRIPTION
Fixes #1 in this module, and also [launchctl](https://github.com/andrewp-as-is/launchctl.py) on Python 3.10+